### PR TITLE
2020 Settings Menu Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'io.acari'
-version '7.0.3'
+version '7.0.4'
 
 repositories {
     maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 }
 
 intellij {
-    version '2019.3.4'
+    version '2020.1'
     type 'IU'
     alternativeIdePath idePath
 }

--- a/changelog/CHANGELOG.html
+++ b/changelog/CHANGELOG.html
@@ -1,5 +1,13 @@
 <h1>Changelog</h1>
 <hr/>
+<h1>7.0.4</h1>
+<ul>
+  <li>Settings menu available for 2020 Builds</li>
+  <li>Added <code>Don&#39;t show readme on startup</code> option.<ul>
+    <li>That way you can admire your theme&#39;s background art!</li>
+  </ul>
+  </li>
+</ul>
 <h1>7.0.3</h1>
 <ul>
   <li>Fixed issue with unavailable themes showing up in settings.<ul>

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 ---
+# 7.0.4
+
+- Settings menu available for 2020 Builds
+- Added `Don't show readme on startup` option.
+    - That way you can admire your theme's background art!
+
 # 7.0.3
 
 - Fixed issue with unavailable themes showing up in settings.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-sinceBuildVersion=193.4099
+sinceBuildVersion=201.0
 untilBuildVersion=201.*
 idePath=
 #idePath=C:\\Users\\birdm.DESKTOP-FO92PV5\\AppData\\Local\\JetBrains\\Toolbox\\apps\\IDEA-U\\ch-0\\193.6015.39

--- a/src/main/kotlin/io/acari/doki/config/ThemeConfig.kt
+++ b/src/main/kotlin/io/acari/doki/config/ThemeConfig.kt
@@ -21,6 +21,7 @@ class ThemeConfig : PersistentStateComponent<ThemeConfig>, Cloneable {
   }
 
   var isLafAnimation: Boolean = false
+  var isNotShowReadmeAtStartup: Boolean = false
   var version: String = "0.0.0"
   var chibiLevel: String = StickerLevel.ON.name
   var stickerLevel: String = StickerLevel.ON.name

--- a/src/main/kotlin/io/acari/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/acari/doki/notification/UpdateNotification.kt
@@ -7,21 +7,14 @@ import com.intellij.openapi.project.Project
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-        <li>Added 5 new themes!
-            <ul>
-                <li>Re:Zero - Emilia (light/dark)</li>
-                <li>DanganRonpa - Mioda Ibuki (light/dark)</li>
-                <li>Hatsune Miku (dark)</li>
-            </ul>
-        </li>
-        <li>Fixed all reported exceptions.</li>
+        <li>The Doki-Theme settings menu is back!</li>
       </ul>
       <br>Please see the <a href="https://github.com/Unthrottled/doki-theme-jetbrains/blob/master/changelog/CHANGELOG.md">Changelog</a> for more details.
       <br>
       Thanks again for downloading <b>The Doki Theme</b>! •‿•<br>
 """.trimIndent()
 
-const val CURRENT_VERSION = "7.0.3"
+const val CURRENT_VERSION = "7.0.4"
 
 object UpdateNotification {
 

--- a/src/main/kotlin/io/acari/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/acari/doki/notification/UpdateNotification.kt
@@ -79,7 +79,16 @@ object UpdateNotification {
       notificationManager.notify(
         "Theme Transition Animation Enabled",
         """The animations will remain in your IDE after uninstalling the plugin.
-          |To remove them, un-check this action or remove them at "Help -> Find Action -> ide.intellij.laf.enable.animation". 
+          |To remove them, un-check this action or toggle the action at "Help -> Find Action -> ide.intellij.laf.enable.animation". 
+        """.trimMargin()
+      )
+    }
+
+    fun displayReadmeInstallMessage() {
+      notificationManager.notify(
+        "README.md will not show on startup",
+        """This behavior will remain in your IDE after uninstalling the plugin.
+          |To re-enable it, un-check this action or toggle the action at "Help -> Find Action -> ide.open.readme.md.on.startup". 
         """.trimMargin()
       )
     }

--- a/src/main/kotlin/io/acari/doki/settings/ThemeSettings.kt
+++ b/src/main/kotlin/io/acari/doki/settings/ThemeSettings.kt
@@ -27,7 +27,8 @@ data class ThemeSettingsModel(
   var isSwappedSticker: Boolean,
   var isMaterialDirectories: Boolean,
   var isMaterialFiles: Boolean,
-  var isMaterialPSIIcons: Boolean
+  var isMaterialPSIIcons: Boolean,
+  var isNotShowReadmeAtStartup: Boolean
 )
 
 class ThemeSettings : SearchableConfigurable {
@@ -57,7 +58,8 @@ class ThemeSettings : SearchableConfigurable {
     ThemeConfig.instance.currentSticker == CurrentSticker.SECONDARY,
     ThemeConfig.instance.isMaterialDirectories,
     ThemeConfig.instance.isMaterialFiles,
-    ThemeConfig.instance.isMaterialPSIIcons
+    ThemeConfig.instance.isMaterialPSIIcons,
+    ThemeConfig.instance.isNotShowReadmeAtStartup
   )
 
   private val themeSettingsModel = initialThemeSettingsModel.copy()
@@ -68,6 +70,7 @@ class ThemeSettings : SearchableConfigurable {
 
   override fun apply() {
     LafAnimationActor.enableAnimation(themeSettingsModel.isLafAnimation)
+    ShowReadmeActor.dontShowReadmeOnStartup(themeSettingsModel.isNotShowReadmeAtStartup)
     FileColorActor.enableFileColors(themeSettingsModel.isFileColors)
     StickerActor.enableStickers(themeSettingsModel.areStickersEnabled, false)
     StickerActor.swapStickers(themeSettingsModel.isSwappedSticker, false)
@@ -227,11 +230,26 @@ class ThemeSettings : SearchableConfigurable {
             "Theme Transition Animation",
             themeSettingsModel.isFileColors,
             comment = """The animations will remain in your IDE after uninstalling the plugin.
-            |To remove them, un-check this action or remove them at "Help -> Find Action -> ide.intellij.laf.enable.animation". 
+            |To remove them, un-check this action or toggle the action at "Help -> Find Action -> ide.intellij.laf.enable.animation". 
             """.trimMargin()
             ,
             actionListener = { _, component ->
               themeSettingsModel.isFileColors = component.isSelected
+            }
+          )
+        }
+        row {
+          checkBox(
+            "Don't show README on project startup",
+            themeSettingsModel.isNotShowReadmeAtStartup,
+            comment = """Anytime you open a new project, don't automatically open the README.
+              |That way you can admire your theme's background art instead!
+            |This will stay even after you uninstall the plugin.
+|To re-enable it, un-check this action or toggle the action at "Help -> Find Action -> ide.open.readme.md.on.startup". 
+            """.trimMargin()
+            ,
+            actionListener = { _, component ->
+              themeSettingsModel.isNotShowReadmeAtStartup = component.isSelected
             }
           )
         }

--- a/src/main/kotlin/io/acari/doki/settings/actors/ShowReadmeActor.kt
+++ b/src/main/kotlin/io/acari/doki/settings/actors/ShowReadmeActor.kt
@@ -1,0 +1,17 @@
+package io.acari.doki.settings.actors
+
+import com.intellij.openapi.util.registry.Registry
+import io.acari.doki.config.ThemeConfig
+import io.acari.doki.notification.UpdateNotification
+
+object ShowReadmeActor {
+  fun dontShowReadmeOnStartup(enabled: Boolean) {
+    if (enabled != ThemeConfig.instance.isNotShowReadmeAtStartup) {
+      ThemeConfig.instance.isNotShowReadmeAtStartup = enabled
+      Registry.get("ide.open.readme.md.on.startup").setValue(!enabled)
+      if (enabled) {
+          UpdateNotification.displayReadmeInstallMessage()
+      }
+    }
+  }
+}

--- a/todo
+++ b/todo
@@ -1,3 +1,5 @@
+Don't show readme option
+
 Stretch Goals
 ----
 - Normalize Dark Literature Club (less crazy stickers first)

--- a/todo
+++ b/todo
@@ -1,5 +1,3 @@
-Don't show readme option
-
 Stretch Goals
 ----
 - Normalize Dark Literature Club (less crazy stickers first)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Building the plugin with the 2020 SDK, that way the Kotlin DSL creates the right UI stuff.

Also added `Don't Show Readme on startup settings option`.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes the issue with the 2020 builds not having a settings menu.

As for the don't show readme, you can admire your theme's background art when you start a new project.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Works on this
```
IntelliJ IDEA 2020.1 (Ultimate Edition)
Build #IU-201.6668.121, built on April 8, 2020
Licensed to Alex Simons
Subscription is active until February 21, 2021
Runtime version: 11.0.6+8-b765.25 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Linux 4.15.0-91-generic
GC: G1 Young Generation, G1 Old Generation
Memory: 512M
Cores: 12
Registry: ide.open.readme.md.on.startup=false
Non-Bundled Plugins: io.acari.DDLCTheme
Current Desktop: ubuntu:GNOME
```

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I updated the version.
- [x] I updated the changelog with the new functionality.